### PR TITLE
fix recursive concatenation

### DIFF
--- a/update_readme.py
+++ b/update_readme.py
@@ -30,8 +30,16 @@ def update_main_readme(repo_path):
         with open(main_readme_path, 'r') as f:
             existing_content = f.read()
     
-    # Append the consolidated content to the existing content
-    full_content = existing_content + ''.join(consolidated_content)
+    # Find the position where the subdirectory content starts
+    start_marker = "\n\n# "
+    start_index = existing_content.find(start_marker)
+    
+    if start_index == -1:
+        # If no subdirectory content exists, append the new content
+        full_content = existing_content + ''.join(consolidated_content)
+    else:
+        # If subdirectory content exists, replace it with the new content
+        full_content = existing_content[:start_index] + ''.join(consolidated_content)
     
     # Write the full content back to the main README.md
     with open(main_readme_path, 'w') as f:


### PR DESCRIPTION
Script now looks for a marker (`"\n\n# "`) in the existing content of the main README.md file. This marker indicates where the subdirectory content begins.

* If it finds this marker, it will  replace everything after it with the new consolidated content from the subdirectories.
* If it doesn't find the marker (which would be the case the first time the script is run),  it will append the consolidated content as before.

This approach ensures that:

* The original content of the main README.md (before the subdirectory content) is preserved.
* The subdirectory content is updated rather than appended each time the script is run.
* If there's no existing subdirectory content, it behaves like the original script.

To use this script effectively, make sure that  main README.md file has a clear separation between its original content and the content from subdirectories. The script uses the first occurrence of a line starting with "# " (after a blank line) as the marker for where subdirectory content begins.