### PR TITLE
add version verfication command to slurm script

### DIFF
--- a/1-apptainer-build/build-container.slurm
+++ b/1-apptainer-build/build-container.slurm
@@ -43,3 +43,14 @@ unset APPTAINER_BIND
 
 
 apptainer build --warn-unused-build-args --force --fakeroot ${IMAGE_PATH}/apsim-${APSIM_VERSION}.aimg Apptainer.def
+
+
+# Verify the built version
+BUILT_VERSION=$(apptainer exec ${IMAGE_PATH}/apsim-${APSIM_VERSION}.aimg Models | grep APSIM | awk -F'[ ©]' '{print $2}')
+
+if [ "$BUILT_VERSION" == "$APSIM_VERSION" ]; then
+    echo "Version verification successful: $BUILT_VERSION"
+else
+    echo "Version verification failed: expected $APSIM_VERSION, got $BUILT_VERSION"
+    exit 1
+fi


### PR DESCRIPTION
Explanation of the changes:

`apptainer exec ... | grep APSIM ` This command extracts the version number from the output of the Models command executed inside the Apptainer image. It assumes that the output format is "APSIM <version>".

-`F'[ ©]'` sets the field separator to either a space or the © symbol. Otherwise, output comes in the format of `version ©`
- `'{print $2}'` prints the second field, which should be the version number. 

This approach should correctly extract just the version number (e.g., "2024.8.7572.0") without any additional characters.
