### PR TITLE
change Snakefile_txt to become the primary which triggers Snakeflie_apsimx at the end 

### DIFF
--- a/08-snakemake/Snakefile_txt
+++ b/08-snakemake/Snakefile_txt
@@ -14,7 +14,8 @@ txt_files = [f for f in glob("*.txt") if f not in config["excluded_txt_files"]]
 rule all:
     input:
         config["slurm_logdir"],
-        "txt_files_processed"
+        "txt_files_processed",
+        "apsimx_workflow_complete"
 
 rule process_txt_files:
     input:
@@ -63,3 +64,14 @@ rule create_logdir:
         directory(config["slurm_logdir"])
     shell:
         "mkdir -p {output}"
+
+rule run_apsimx_workflow:
+    input:
+        "txt_files_processed"
+    output:
+        "apsimx_workflow_complete"
+    shell:
+        """
+        snakemake -s Snakefile_apsimx --cores all
+        touch {output}
+        """


### PR DESCRIPTION
1. We added a new output file `apsimx_workflow_complete` to the` all` rule. This ensures that the Snakemake workflow will not be considered complete until the APSIMX workflow has finished.
2. Created a new rule called `run_apsimx_workflow`:

  - This rule depends on the `txt_files_processed` output, ensuring it only runs after all text files have been processed.
  - It produces an output file `apsimx_workflow_complete`.
  - The rule uses a shell command to run Snakemake with Snakefile_apsimx.
  - After the APSIMX workflow completes, it touches the output file to mark completion.


With these changes, when we run `snakemake -s Snakefile_txt`, it will:

1. Process all the text files first.
2. Once all text files are processed, it will automatically start the APSIMX workflow by running `Snakefile_apsimx`.
3. The overall workflow will only be considered complete when both the text file processing and the APSIMX workflow have finished.