### PR TITLE
update output directories for each snakefile

### DIFF
--- a/08-snakemake/Snakefile_apsimx
+++ b/08-snakemake/Snakefile_apsimx
@@ -44,7 +44,11 @@ rule create_logdir:
     output:
         directory(config["slurm_logdir"])
     shell:
-        "mkdir -p {output}"
+	    """
+        mkdir -p {output}
+        mkdir -p PASSED_DB
+        mkdir -p FAILED_DB
+        """
 
 rule sort_db_files:
     input:
@@ -52,8 +56,8 @@ rule sort_db_files:
     output:
         "db_files_sorted"
     run:
-        passed_dir = "PASSED"
-        failed_dir = "FAILED"
+        passed_dir = "PASSED_DB"
+        failed_dir = "FAILED_DB"
         os.makedirs(passed_dir, exist_ok=True)
         os.makedirs(failed_dir, exist_ok=True)
 

--- a/08-snakemake/Snakefile_txt
+++ b/08-snakemake/Snakefile_txt
@@ -35,7 +35,7 @@ rule process_txt_files:
         export APPTAINER_BIND="{config[apptainer_bind]}"
         export APPTAINER_CMD="apptainer exec {config[apptainer_image]}"
         
-        mkdir -p FAILED
+        mkdir -p FAILED_CONFIG
         consecutive_failures=0
         max_consecutive_failures={config[max_consecutive_failures]}
         
@@ -45,7 +45,7 @@ rule process_txt_files:
                 consecutive_failures=0
             else
                 echo "Failed to process $file"
-                mv "$file" FAILED/
+                mv "$file" FAILED_CONFIG/
                 ((consecutive_failures++))
                 
                 if [ $consecutive_failures -ge $max_consecutive_failures ]; then


### PR DESCRIPTION
Current Snakefiles creates PASSED and FAILED directories for both processing Config files and processing apsimx files which makes it difficult to distinguish . 